### PR TITLE
Add option to bypass SMTPUTF8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ smtpproto = py.typed
 
 [options.extras_require]
 test =
-    aiosmtpd >= 1.2
+    aiosmtpd == 1.2
     coverage >= 4.5
     curio >= 1.2
     pytest >= 6.0

--- a/src/smtpproto/protocol.py
+++ b/src/smtpproto/protocol.py
@@ -59,7 +59,7 @@ class SMTPClientProtocol:
     """The (E)SMTP protocol state machine."""
 
     _state: ClientState = field(init=False, default=ClientState.greeting_expected)
-    _smtputf8_message: bool = field(init=False, default=False)
+    _smtputf8_message: bool = field(init=False, default=True)
     _out_buffer: bytes = field(init=False, default=b'')
     _in_buffer: bytes = field(init=False, default=b'')
     _response_code: Optional[int] = field(init=False, default=None)
@@ -299,18 +299,20 @@ class SMTPClientProtocol:
         """Send the QUIT command (required to cleanly shut down the session)."""
         self._send_command('QUIT')
 
-    def mail(self, sender: Union[str, Address], smtputf8: bool = True) -> None:
+    def mail(self, sender: Union[str, Address], *, smtputf8: bool = True) -> None:
         """
         Send the MAIL FROM command (starts a mail transaction).
 
         :param sender: the sender's email address
         :param smtputf8: send the SMTPUTF8 option, if available on the server
+
         """
         self._require_state(ClientState.ready, ClientState.authenticated)
 
         args = []
         if '8BITMIME' in self._extensions:
             args.append('BODY=8BITMIME')
+
         if smtputf8 and 'SMTPUTF8' in self._extensions:
             self._smtputf8_message = True
             args.append('SMTPUTF8')

--- a/src/smtpproto/protocol.py
+++ b/src/smtpproto/protocol.py
@@ -92,24 +92,17 @@ class SMTPClientProtocol:
         else:
             address_str = address
 
-        if self._smtputf8_message and 'SMTPUTF8' in self._extensions:
+        if self._smtputf8_message:
             return address_str.encode('utf-8')
 
         # If SMPTUTF8 is not supported, the address must be ASCII compatible
         try:
             return address_str.encode('ascii')
         except UnicodeEncodeError:
-            if self._smtputf8_message:
-                message = (
-                    f'The address {address_str!r} requires UTF-8 encoding but the server does not '
-                    'support the SMTPUTF8 extension'
-                )
-            else:
-                message = (
-                    f'The address {address_str!r} requires UTF-8 encoding but smtputf8_option was '
-                    'not specified in the mail command'
-                )
-            raise SMTPProtocolViolation(message)
+            raise SMTPProtocolViolation(
+                f'The address {address_str!r} requires UTF-8 encoding but the server does not '
+                'support the SMTPUTF8 extension or SMTPUTF8 was not specified in the mail command'
+            )
 
     def _send_command(self, command: str, *args: Union[str, bytes]) -> None:
         if self._command_sent is not None:

--- a/src/smtpproto/protocol.py
+++ b/src/smtpproto/protocol.py
@@ -99,10 +99,16 @@ class SMTPClientProtocol:
         try:
             return address_str.encode('ascii')
         except UnicodeEncodeError:
-            raise SMTPProtocolViolation(
-                f'The address {address_str!r} requires UTF-8 encoding but the server does not '
-                'support the SMTPUTF8 extension or SMTPUTF8 was not specified in the mail command'
-            )
+            if 'SMTPUTF8' in self._extensions:
+                raise SMTPProtocolViolation(
+                    f'The address {address_str!r} requires UTF-8 encoding but `smtputf8` was not '
+                    'specified in the mail command'
+                )
+            else:
+                raise SMTPProtocolViolation(
+                    f'The address {address_str!r} requires UTF-8 encoding but the server does not '
+                    'support the SMTPUTF8 extension'
+                )
 
     def _send_command(self, command: str, *args: Union[str, bytes]) -> None:
         if self._command_sent is not None:

--- a/src/smtpproto/protocol.py
+++ b/src/smtpproto/protocol.py
@@ -59,6 +59,7 @@ class SMTPClientProtocol:
     """The (E)SMTP protocol state machine."""
 
     _state: ClientState = field(init=False, default=ClientState.greeting_expected)
+    _smtputf8_message: bool = field(init=False, default=False)
     _out_buffer: bytes = field(init=False, default=b'')
     _in_buffer: bytes = field(init=False, default=b'')
     _response_code: Optional[int] = field(init=False, default=None)
@@ -91,16 +92,24 @@ class SMTPClientProtocol:
         else:
             address_str = address
 
-        if 'SMTPUTF8' in self._extensions:
+        if self._smtputf8_message and 'SMTPUTF8' in self._extensions:
             return address_str.encode('utf-8')
 
         # If SMPTUTF8 is not supported, the address must be ASCII compatible
         try:
             return address_str.encode('ascii')
         except UnicodeEncodeError:
-            raise SMTPProtocolViolation(
-                f'The address {address_str!r} requires UTF-8 encoding but the server does not '
-                f'support the SMTPUTF8 extension')
+            if self._smtputf8_message:
+                message = (
+                    f'The address {address_str!r} requires UTF-8 encoding but the server does not '
+                    'support the SMTPUTF8 extension'
+                )
+            else:
+                message = (
+                    f'The address {address_str!r} requires UTF-8 encoding but smtputf8_option was '
+                    'not specified in the mail command'
+                )
+            raise SMTPProtocolViolation(message)
 
     def _send_command(self, command: str, *args: Union[str, bytes]) -> None:
         if self._command_sent is not None:
@@ -297,20 +306,23 @@ class SMTPClientProtocol:
         """Send the QUIT command (required to cleanly shut down the session)."""
         self._send_command('QUIT')
 
-    def mail(self, sender: Union[str, Address]) -> None:
+    def mail(self, sender: Union[str, Address], smtputf8: bool = True) -> None:
         """
         Send the MAIL FROM command (starts a mail transaction).
 
         :param sender: the sender's email address
-
+        :param smtputf8: send the SMTPUTF8 option, if available on the server
         """
         self._require_state(ClientState.ready, ClientState.authenticated)
 
         args = []
         if '8BITMIME' in self._extensions:
             args.append('BODY=8BITMIME')
-        if 'SMTPUTF8' in self._extensions:
+        if smtputf8 and 'SMTPUTF8' in self._extensions:
+            self._smtputf8_message = True
             args.append('SMTPUTF8')
+        else:
+            self._smtputf8_message = False
 
         self._send_command('MAIL', b'FROM:<' + self._encode_address(sender) + b'>', *args)
 
@@ -346,7 +358,7 @@ class SMTPClientProtocol:
 
         """
         self._require_state(ClientState.send_data)
-        policy: Policy = SMTPUTF8 if 'SMTPUTF8' in self._extensions else SMTP
+        policy: Policy = SMTPUTF8 if self._smtputf8_message else SMTP
         policy = policy.clone(cte_type='7bit') if '8BITMIME' not in self._extensions else policy
         self._out_buffer += message.as_bytes(policy=policy).replace(b'\r\n.', b'\r\n..')
         self._out_buffer += b'.\r\n'

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -143,14 +143,19 @@ def test_send_mail_utf8_addresses(protocol, unicode_address):
 def test_send_mail_unicode_sender_encoding_error(protocol, unicode_address):
     exchange_greetings(protocol, esmtp=False)
     exc = pytest.raises(SMTPProtocolViolation, protocol.mail, unicode_address)
-    exc.match("^The address 'héllö@example.org' requires UTF-8")
+    exc.match(
+        "^The address 'héllö@example.org' requires UTF-8 encoding but the server does not support "
+        "the SMTPUTF8 extension"
+    )
 
 
 def test_send_mail_unicode_sender_no_smtputf8_encoding_error(protocol, unicode_address):
     exchange_greetings(protocol, esmtp=True)
     exc = pytest.raises(SMTPProtocolViolation, protocol.mail, unicode_address,
                         smtputf8=False)
-    exc.match("^The address 'héllö@example.org' requires UTF-8")
+    exc.match(
+        "^The address 'héllö@example.org' requires UTF-8 encoding but `smtputf8` was not specified"
+    )
 
 
 def test_send_mail_unicode_recipient_encoding_error(protocol, unicode_address):


### PR DESCRIPTION
Allows email clients to send SMTPUTF8 only for messages where it is required.

Should address #3.

